### PR TITLE
Replaced fabpot/php-cs-fixer with friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "simgroep/coding-standards",
   "description": "Coding standard configuration for SIMGroep PHP projects using fabpot/php-cs-fixer",
   "require": {
-    "fabpot/php-cs-fixer": "^1.10"
+    "friendsofphp/php-cs-fixer": "^1.11"
   },
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
Because `fabpot/php-cs-fixer` is abandoned: https://packagist.org/packages/fabpot/php-cs-fixer
