### PR TITLE
Finder should use current working dir

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -29,6 +29,6 @@ return Symfony\CS\Config\Config::create()
     ))
     ->finder(
         Symfony\CS\Finder\DefaultFinder::create()
-            ->in(__DIR__)
+            ->in(getcwd())
     )
 ;


### PR DESCRIPTION
Otherwise the fixer will run on the coding-standards repository if no path is given.