### PR TITLE
Fix namespace and strict types blank line issue

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -33,6 +33,7 @@ return \PhpCsFixer\Config::create()
         'single_quote'                          => true, // Convert double quotes to single quotes for simple strings.
         'standardize_not_equals'                => true, // Replace all <> with !=.
         'trailing_comma_in_multiline_array'     => true, // PHP multi-line arrays should have a trailing comma.
+        'single_blank_line_before_namespace'    => true, // There should be exactly one blank line before a namespace declaration.
 
     ])
     ->setFinder(


### PR DESCRIPTION
Fix for whitespace around strict_types and namespace.